### PR TITLE
Use "a" instead of "an"

### DIFF
--- a/src/clojure/reagi/core.clj
+++ b/src/clojure/reagi/core.clj
@@ -142,7 +142,7 @@
   (identical? x no-value))
 
 (defn events
-  "Create an referential stream of events. The stream may be instantiated from
+  "Create a referential stream of events. The stream may be instantiated from
   an existing core.async channel, otherwise a new channel will be created.
   Streams instantiated from existing channels are closed by default.
 


### PR DESCRIPTION
I'm using the following guidelines:

"Use an before a word that starts with a vowel sound.
If it does not start with a vowel sound, use a."

---

http://www.grammar-monster.com/lessons/an_or_a.htm
